### PR TITLE
fix(core): Fixed incorrect generic function naming

### DIFF
--- a/packages/core/src/type-graph/types/function-type.js
+++ b/packages/core/src/type-graph/types/function-type.js
@@ -146,7 +146,7 @@ export class FunctionType extends Type {
     throws?: Type | void
   ) {
     const asyncPart = this.getAsyncPart(isAsync);
-    const genericPart = this.getGenericPart(
+    let genericPart = this.getGenericPart(
       genericParams,
       this.prettyMode && genericParams.length >= 4
     );
@@ -159,6 +159,9 @@ export class FunctionType extends Type {
     );
     const throwsPart = this.getThrowsPart(throws);
     const returnPart = this.getReturnPart(returnType);
+
+    genericPart = params.length !== 0 ? genericPart : ""
+
     return this.prettyMode
       ? this.multyLine(asyncPart, genericPart, argsPart, throwsPart, returnPart)
       : this.oneLine(asyncPart, genericPart, argsPart, throwsPart, returnPart);


### PR DESCRIPTION
Inspired by OCaml

OCaml:
<img width="365" alt="Screenshot 2020-04-12 at 15 40 09" src="https://user-images.githubusercontent.com/26031322/79069053-f5159f00-7cd3-11ea-9ae5-d6cd1a856c05.png">
<img width="365" alt="Screenshot 2020-04-12 at 15 40 04" src="https://user-images.githubusercontent.com/26031322/79069057-f646cc00-7cd3-11ea-98e9-4058304051b9.png">

Hegel:
<img width="359" alt="Screenshot 2020-04-12 at 15 41 13" src="https://user-images.githubusercontent.com/26031322/79069102-27270100-7cd4-11ea-9433-798c7f778830.png">
<img width="359" alt="Screenshot 2020-04-12 at 15 41 50" src="https://user-images.githubusercontent.com/26031322/79069100-25f5d400-7cd4-11ea-9277-76181787d19d.png">


I do not think that it is correct, that Hegel shows a type for "always" function like it does now. It looks like that function has two generic arguments, but they have the same key

<img width="305" alt="Screenshot 2020-04-12 at 19 41 44" src="https://user-images.githubusercontent.com/26031322/79074533-aaa51a00-7cf5-11ea-892b-db1b7f911c23.png">
