### PR TITLE
Add fill method to Array interface

### DIFF
--- a/packages/typings/standard/index.d.ts
+++ b/packages/typings/standard/index.d.ts
@@ -212,7 +212,7 @@ interface Array<T> {
   find(fn: (el: T) => boolean): T | undefined;
   findIndex(fn: (el: T) => boolean): number;
   // Fills array with [value] from [start] index (0 by default) to [end] (length of array by default).
-  // Returns new changed array.
+  // Changes source array and returns it.
   fill(value: T, start?: number, end?: number): T[];
   //     /**
   //       * Returns the index of the last occurrence of a specified value in an array.

--- a/packages/typings/standard/index.d.ts
+++ b/packages/typings/standard/index.d.ts
@@ -211,6 +211,9 @@ interface Array<T> {
   includes(searchElement: T): boolean;
   find(fn: (el: T) => boolean): T | undefined;
   findIndex(fn: (el: T) => boolean): number;
+  // Fills array with [value] from [start] index (0 by default) to [end] (length of array by default).
+  // Returns new changed array.
+  fill(value: T, start?: number, end?: number): T[];
   //     /**
   //       * Returns the index of the last occurrence of a specified value in an array.
   //       * @param searchElement The value to locate in the array.


### PR DESCRIPTION
I have add missing method to `Array` interface. [Issue](https://github.com/JSMonk/hegel/issues/68)