### PR TITLE
add of method signature

### DIFF
--- a/packages/typings/standard/index.d.ts
+++ b/packages/typings/standard/index.d.ts
@@ -5032,6 +5032,11 @@ interface ArrayConstructor {
    * @param iterable An iterable object to convert to an array.
    */
   from<T>(iterable: Iterable<T> | ArrayLike<T>): T[];
+  /**
+   * Returns a new array from a set of elements.
+   * @param items A set of elements to include in the new array object.
+   */
+  of<T>(...items: T[]): T[];
 }
 
 declare var Array: ArrayConstructor;


### PR DESCRIPTION
I noticed that there is no **`of`** signature in `ArrayConstructor`, so i decided to add it.
https://github.com/JSMonk/hegel/issues/106