### PR TITLE
feat(core): Initial implementation of exhaustive check

### DIFF
--- a/packages/core/src/type-graph/type-graph.js
+++ b/packages/core/src/type-graph/type-graph.js
@@ -599,6 +599,45 @@ const afterFillierActions = (
           moduleScope.addPosition(currentNode.catchBlock.param, errorVariable);
         }
         break;
+      case NODE.SWITCH_STATEMENT:
+        const { discriminant, cases } = currentNode;
+        let hasDefaultCase = cases.some(switchCase => switchCase.test === null); // test equals null only if it's default case
+        let matchedVariants = [...currentScope.findVariable(discriminant).type.variants]
+
+        if (!hasDefaultCase) { // if switch statement doesn't have default case, we should check whether cases exhaustive or not
+          cases.forEach((switchCase) => {
+            let matcherValue = switchCase.test.value; // by default we can take raw value, it works for NUMER_LITERAL
+
+            switch(switchCase.test.type) {
+              case NODE.STRING_LITERAL: // to match string value with variant type we have to add single quotes around a value
+                matcherValue = `'${switchCase.test.value}'`;
+                break;
+              case NODE.IDENTIFIER:
+                matcherValue = currentScope.findVariable(switchCase.test).type;
+
+                if (matcherValue instanceof UnionType) {
+                  errors.push(
+                    new HegelError('It is not safe to use variable which type is Union as case matcher, you should infer it value first', switchCase.loc)
+                  );
+                }
+                break;
+              // TODO add suport for CallExpression, TemplateLiteral, ...
+            }
+
+            matchedVariants = matchedVariants.filter(variant => variant.name !== matcherValue)
+          })
+
+          if (matchedVariants.length !== 0 && !hasDefaultCase) {
+            const notMatchedCases = matchedVariants.map(variants => variants.name).join(" | ")
+
+            errors.push(new HegelError(
+              `This switch case statement is not exhaustive. Here is an example of a case that is not matched: ${notMatchedCases}`,
+              currentNode.loc
+            ));
+          }
+        }
+
+        break;
       case NODE.IF_STATEMENT:
       case NODE.RETURN_STATEMENT:
       case NODE.EXPRESSION_STATEMENT:


### PR DESCRIPTION
This implementation currently works only with StringLiteral and NumberLiteral.

<img width="382" alt="Screenshot 2020-04-17 at 23 05 38" src="https://user-images.githubusercontent.com/26031322/79609898-2f31d700-8100-11ea-9471-070dc40484ee.png">
<img width="854" alt="Screenshot 2020-04-17 at 23 05 48" src="https://user-images.githubusercontent.com/26031322/79609891-2d681380-8100-11ea-8e17-edc11880a68f.png">

There is a lot of work to do... I can implement it to work with CallExpression, Identifier etc, but a little bit later =)

I would like you to leave a comment if you are not ok with this implementation, I will fix it soon if here any.
