### PR TITLE
build: use local version of core package in docs dev mode

### DIFF
--- a/packages/docs/gatsby-node.js
+++ b/packages/docs/gatsby-node.js
@@ -1,11 +1,20 @@
 const fs = require("fs");
+const path = require("path");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
+
+const { NODE_ENV } = process.env;
 
 const REPOSITORY = "https://github.com/JSMonk/hegel";
 const STD_LIB_PATH = "@hegel/typings/standard/index.d.ts";
 const STD_LIB_CONTENT = fs
   .readFileSync(require.resolve(STD_LIB_PATH), "utf8")
   .replace(/`/g, "");
+
+const resolve = NODE_ENV !== 'production' ?  {
+  alias: {
+    '@hegel/core': path.resolve(__dirname, '../../core/build/'),
+  },
+} : {};
 
 exports.onCreateWebpackConfig = args => {
   args.actions.setWebpackConfig({
@@ -17,6 +26,7 @@ exports.onCreateWebpackConfig = args => {
       new MonacoWebpackPlugin({
         languages: ["javascript", "css", "html", "typescript", "json"]
       })
-    ]
+    ],
+    resolve
   });
 };

--- a/packages/docs/gatsby-node.js
+++ b/packages/docs/gatsby-node.js
@@ -10,9 +10,11 @@ const STD_LIB_CONTENT = fs
   .readFileSync(require.resolve(STD_LIB_PATH), "utf8")
   .replace(/`/g, "");
 
-const resolve = NODE_ENV !== 'production' ?  {
+const LOCAL_CORE_BUILD = path.resolve(__dirname, '../../core/build/')
+
+const resolve = NODE_ENV !== 'production' && fs.existsSync(LOCAL_CORE_BUILD)?  {
   alias: {
-    '@hegel/core': path.resolve(__dirname, '../../core/build/'),
+    '@hegel/core': LOCAL_CORE_BUILD,
   },
 } : {};
 


### PR DESCRIPTION
this will use a local build of `@hegel/core` package in docs if started with `npm run dev`
hot reload is not working so after changes in core packages you need to rebuild it and then restart docs
I experimented a bit trying to use not a built version but source but have not found a way, for now, to make it compile correctly 