### PR TITLE
fix(Issue #100): error processing while statement with logical condition

### DIFF
--- a/packages/core/src/utils/common.js
+++ b/packages/core/src/utils/common.js
@@ -66,6 +66,9 @@ export function getMemberExressionTarget(node: MemberExpression): Node {
   return target;
 }
 
-export function ensureArray<T>(value: T | Array<T>): Array<T> {
+export function ensureArray<T>(value: T | Array<T> | null | undefined): Array<T> {
+  if (value === undefined || value == null) {
+    return []
+  }
   return Array.isArray(value) ? value : [value];
 }

--- a/packages/core/src/utils/common.js
+++ b/packages/core/src/utils/common.js
@@ -67,7 +67,7 @@ export function getMemberExressionTarget(node: MemberExpression): Node {
 }
 
 export function ensureArray<T>(value: T | Array<T> | null | undefined): Array<T> {
-  if (value === undefined || value == null) {
+  if (value === undefined || value === null) {
     return []
   }
   return Array.isArray(value) ? value : [value];

--- a/packages/core/src/utils/common.js
+++ b/packages/core/src/utils/common.js
@@ -65,3 +65,7 @@ export function getMemberExressionTarget(node: MemberExpression): Node {
   } while (target.type === NODE.MEMBER_EXPRESSION);
   return target;
 }
+
+export function ensureArray<T>(value: T | Array<T>): Array<T> {
+  return Array.isArray(value) ? value : [value];
+}

--- a/packages/core/src/utils/nodes.js
+++ b/packages/core/src/utils/nodes.js
@@ -201,15 +201,15 @@ export const isScopeCreator = (node: Node) =>
     EXPRESSIONS_TYPES.ARROW_FUNCTION_EXPRESSION
   ].includes(node.type);
 
-export const isFunction = (node: ?Node) =>
-  node !== undefined ? [
+export const isFunction = (node: Node) =>
+  [
     DECLARATION_TYPES.FUNCTION_DECLARATION,
     EXPRESSIONS_TYPES.FUNCTION_EXPRESSION,
     EXPRESSIONS_TYPES.ARROW_FUNCTION_EXPRESSION,
     ANNOTATION_TYPES.FUNCTION_TYPE_ANNOTATION,
     OBJECT_PROPERTIES.OBJECT_METHOD,
     CLASS_PROPERTIES.CLASS_METHOD
-  ].includes(node.type) : false;
+  ].includes(node.type);
 
 export const isImport = (node: Node) =>
   node.type === DECLARATION_TYPES.IMPORT_DECLARATION;

--- a/packages/core/src/utils/nodes.js
+++ b/packages/core/src/utils/nodes.js
@@ -201,15 +201,15 @@ export const isScopeCreator = (node: Node) =>
     EXPRESSIONS_TYPES.ARROW_FUNCTION_EXPRESSION
   ].includes(node.type);
 
-export const isFunction = (node: Node) =>
-  [
+export const isFunction = (node: ?Node) =>
+  node !== undefined ? [
     DECLARATION_TYPES.FUNCTION_DECLARATION,
     EXPRESSIONS_TYPES.FUNCTION_EXPRESSION,
     EXPRESSIONS_TYPES.ARROW_FUNCTION_EXPRESSION,
     ANNOTATION_TYPES.FUNCTION_TYPE_ANNOTATION,
     OBJECT_PROPERTIES.OBJECT_METHOD,
     CLASS_PROPERTIES.CLASS_METHOD
-  ].includes(node.type);
+  ].includes(node.type) : false;
 
 export const isImport = (node: Node) =>
   node.type === DECLARATION_TYPES.IMPORT_DECLARATION;

--- a/packages/core/src/utils/traverse.js
+++ b/packages/core/src/utils/traverse.js
@@ -1,5 +1,6 @@
 // @flow
 import NODE from "./nodes";
+import { ensureArray } from "../utils/common";
 import HegelError, { UnreachableError } from "./errors";
 import type { Node, Declaration, Block, SourceLocation } from "@babel/parser";
 
@@ -243,7 +244,7 @@ function mixParentToClassObjectAndFunction(
     typeof currentNode === "object" &&
     currentNode !== null &&
     (currentNode.type === NODE.CLASS_DECLARATION ||
-      currentNode.type === NODE.FUNCITON_DECLARATION)
+      currentNode.type === NODE.FUNCTION_DECLARATION)
   ) {
     currentNode.parentNode = parentNode;
   }
@@ -289,10 +290,10 @@ function mixElseIfReturnOrThrowExisted(currentNode: Node, parentNode: Node) {
 }
 
 const getBody = (currentNode: any) =>
-  currentNode.body ||
-  currentNode.declarations ||
-  currentNode.properties ||
   [
+    ...ensureArray(currentNode.body),
+    ...ensureArray(currentNode.declarations),
+    ...ensureArray(currentNode.properties),
     currentNode.block,
     currentNode.handler,
     currentNode.test,
@@ -309,13 +310,11 @@ const getBody = (currentNode: any) =>
     currentNode.expression && currentNode.expression.callee,
     currentNode.expression,
     currentNode.callee,
-    ...(currentNode.elements || []),
-    ...(currentNode.cases || []),
-    ...(currentNode.expressions || []),
-    ...(currentNode.arguments || []).filter(a => !NODE.isFunction(a)),
-    ...(Array.isArray(currentNode.consequent)
-      ? currentNode.consequent
-      : [currentNode.consequent])
+    ...ensureArray(currentNode.elements),
+    ...ensureArray(currentNode.cases),
+    ...ensureArray(currentNode.expressions),
+    ...ensureArray(currentNode.arguments).filter(a => !NODE.isFunction(a)),
+    ...ensureArray(currentNode.consequent)
   ].filter(Boolean);
 
 const getNextParent = (currentNode: Tree, parentNode: ?Tree) =>
@@ -369,32 +368,25 @@ function traverseTree(
     return;
   }
   const body = getBody(currentNode);
-  if (!body) {
-    return;
-  }
   const nextParent = getNextParent(currentNode, parentNode);
-  if (Array.isArray(body)) {
-    let i = 0;
-    try {
-      for (i = 0; i < body.length; i++) {
-        middle(body[i], nextParent, pre, middle, post, meta);
-      }
-      for (i = 0; i < body.length; i++) {
-        traverseTree(body[i], pre, middle, post, nextParent, {
-          ...meta,
-          kind: currentNode.kind
-        });
-      }
-    } catch (e) {
-      if (!(e instanceof UnreachableError)) {
-        throw e;
-      }
-      if (i < body.length - 1) {
-        throw new HegelError("Unreachable code after this line", e.loc);
-      }
+  let i = 0;
+  try {
+    for (i = 0; i < body.length; i++) {
+      middle(body[i], nextParent, pre, middle, post, meta);
     }
-  } else {
-    traverseTree(body, pre, middle, post, nextParent, meta);
+    for (i = 0; i < body.length; i++) {
+      traverseTree(body[i], pre, middle, post, nextParent, {
+        ...meta,
+        kind: currentNode.kind
+      });
+    }
+  } catch (e) {
+    if (!(e instanceof UnreachableError)) {
+      throw e;
+    }
+    if (i < body.length - 1) {
+      throw new HegelError("Unreachable code after this line", e.loc);
+    }
   }
   post(currentNode, parentNode, pre, middle, post, meta);
 }

--- a/packages/core/tests/type-graph.test.js
+++ b/packages/core/tests/type-graph.test.js
@@ -1501,4 +1501,20 @@ describe("Issues", () => {
 
     expect(errors.length).toBe(0);
   });
+
+  test("Issue #100: error procesing while statement with logical condition", async () => {
+    const sourceAST = prepareAST(`
+      function a(x) { return true; }
+      let id
+      while (id === undefined || a(id)) {	}
+    `);
+    const [, errors] = await createTypeGraph(
+      [sourceAST],
+      getModuleAST,
+      false,
+      mixTypeDefinitions()
+    );
+
+    expect(errors.length).toBe(0);
+  });
 });


### PR DESCRIPTION
the problem was that if a node had `body` property other properties were not traversed (like `test` in `WhileStatement`)
this fix addresses similar problems in other control structures 

fixes #100 