### PR TITLE
Update autocompletion

### DIFF
--- a/packages/language-server/server/validation/code-validation.js
+++ b/packages/language-server/server/validation/code-validation.js
@@ -32,7 +32,7 @@ async function validateTextDocument(textDocument) {
       severity: DiagnosticSeverity.Error,
       range: formatErrorRange(error),
       message: error.message,
-      source: "ex",
+      source: "Hegel",
     }));
 
   return { uri: textDocument.uri, diagnostics };


### PR DESCRIPTION
I have updated getting object's properties algorithm. Now it can show parent's properties also.

```javascript
class Animal {
  name: string = 'noname'
}

class Dog extends Animal {
  rrour() {
    return 'Rrour'
  }
}

class Puppy extends Dog {
  gaw() {
    return 'Gaw'
  }
}

const puppy = new Puppy()
// puppy.name -> VSCode show this field in autocompletion
// puppy.rrour -> VSCode show this method in autocompletion
// puppy.gaw -> VSCode show this method in autocompletion
```