### PR TITLE
docs: Clarify VS code extension instructions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "files.trimTrailingWhitespace": false
+}

--- a/packages/docs/src/docs/docs/editor-plugins.mdx
+++ b/packages/docs/src/docs/docs/editor-plugins.mdx
@@ -26,7 +26,9 @@ To run the extension in debug mode you need to:
 $ git clone https://github.com/JSMonk/hegel
 ```
 
-2. Open `hegel/packages/language-server` in Visual Studio Code
+2. Add `hegel/packages/language-server` to your VS code workspace. Do not
+open `hegel` or add `hegel` to your workspace, otherwise "Run and Debug" cannot
+find the `.vscode/launch.json` configuration.
 
 3. Go to the "Run and Debug" section
 


### PR DESCRIPTION
Clarify that the `.vscode/launch.json` is only understood
if you open the `hegel/packages/language-server` directory
and if you add `hegel` to your workspace or open `hegel` then
it will not work.

Also add a vscode configuration to disable removing trailing
whitespace as that was adding noise to my git diff.