### PR TITLE
Add Dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10
+    # ignore packages that update too frequently
+    ignore: []
+      # Example ignore
+      # - dependency-name: aws-sdk
+      #   versions:
+      #     - ">= 0"


### PR DESCRIPTION
At first this will open a ton of pull requests. Once those are merged, this will work with less noise. We need to merge the CI checks in #299 first to make sure PRs are not breaking tests. 