### PR TITLE
Add test-262 framework

### DIFF
--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,2 +1,3 @@
 tests/testing.test.js
 jest.testing.config.js
+test262/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
     "build:watch": "yarn build -- --watch",
     "build:dev": "yarn build -- --source-maps",
     "build:clean": "rm -rf build",
-    "test": "jest"
+    "test": "jest",
+    "test-262": "node tests/run-262.js"
   },
   "license": "MIT",
   "dependencies": {
@@ -28,6 +29,7 @@
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-flow": "^7.8.3",
     "babel-jest": "^26.0.1",
-    "jest": "^26.0.1"
+    "jest": "^26.0.1",
+    "test262-stream": "^1.3.0"
   }
 }

--- a/packages/core/tests/run-262.js
+++ b/packages/core/tests/run-262.js
@@ -1,0 +1,54 @@
+const path = require("path");
+const cp = require("child_process");
+const fs = require("fs");
+const TestStream = require("test262-stream");
+
+/** The revision of Test262 we test against. @see https://github.com/tc39/test262 */
+const TEST_262_SHA = "00770684b54d922fadfc881bbb134ef71bcabf74";
+
+const test262Dir = path.resolve(process.cwd(), "test262");
+
+if (!fs.existsSync(test262Dir)) {
+  cp.execSync(
+    `git clone git@github.com:tc39/test262.git && cd ${test262Dir} && git reset --hard ${TEST_262_SHA}`
+  );
+}
+
+const stream = new TestStream(test262Dir, {
+  acceptVersion: "2.0.0",
+  omitRuntime: true,
+});
+
+stream.on("data", function(test) {
+  // the path to the file from which the test was derived, relative to the
+  // provided Test262 directory
+  console.log("test.file", test.file);
+
+  // the complete source text for the test; this contains any "includes"
+  // files specified in the frontmatter, "prelude" content if specified (see
+  // below), and any "scenario" transformations
+  console.log("test.contents", test.contents);
+
+  // an object representation of the metadata declared in the test's
+  // "frontmatter" section
+  console.log("test.attrs", test.attrs);
+
+  // the licensing information included within the test (if any)
+  console.log("test.copyright", test.copyright);
+
+  // name describing how the source file was interpreted to create the test
+  console.log("test.scenario", test.scenario);
+
+  // numeric offset within the `contents` string at which one or more
+  // statements may be inserted without necessarily invalidating the test
+  console.log("test.insertionIndex", test.insertionIndex);
+  throw new Error('done')
+});
+
+stream.on("end", function() {
+  console.log("No further tests.");
+});
+
+stream.on("error", function(err) {
+  console.error("Something went wrong:", err);
+});

--- a/packages/core/tests/type-assertion.test.js
+++ b/packages/core/tests/type-assertion.test.js
@@ -3,7 +3,7 @@ import createTypeGraph from "../src/type-graph/type-graph";
 import { Type } from "../src/type-graph/types/type";
 import { prepareAST, mixTypeDefinitions, getModuleAST } from "./preparation";
 
-describe("Variable declrataion and assignment", () => {
+describe("Variable declaration and assignment", () => {
   test("Simple typed const declaration with number literal type", async () => {
     const sourceAST = prepareAST(`
       const a: 2 = 2; 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7956,7 +7956,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -9948,7 +9948,7 @@ js-tokens@^3.0.1, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
+js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.13.1, js-yaml@^3.2.1, js-yaml@^3.9.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -10141,6 +10141,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.1.1.tgz#42b76894701169cc910fd0d19ce677b5fb378af1"
+  integrity sha1-QrdolHARacyRD9DRnOZ3tfs3ivE=
+  dependencies:
+    graceful-fs "^4.1.9"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -15656,6 +15663,14 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+test262-stream@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/test262-stream/-/test262-stream-1.3.0.tgz#98c4ab9f8e74c7f9478afcf52e071a89d319df61"
+  integrity sha512-TSv+Z4hftmRuUJVJk7kaguWLlVLRfwyWm1DOt4kvTXAanATxv6A1HhjRTrSBI00XXEWQ+cUdsDii8tn+fkjXyw==
+  dependencies:
+    js-yaml "^3.2.1"
+    klaw "^2.1.0"
 
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
I suggested this in #298 but now that I've brought in all those test cases I don't know what to do with it?!

Since Babel is parsing the code into AST, I'm not sure those untyped examples would be useful to test against. We can still sanity test the type checker with all those untyped example ASTs. However I'm not sure if that's exactly useful. Please advise. 
